### PR TITLE
Scaffold Redux setup for Chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4224,6 +4224,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -5289,6 +5297,11 @@
         "webpack-sources": "1.4.3"
       }
     },
+    "next-redux-wrapper": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/next-redux-wrapper/-/next-redux-wrapper-6.0.0.tgz",
+      "integrity": "sha512-M+8bglQKZ/IDY98xMkDvXvLRK6N86F6z9suzpGcktOy1ImV18KH8iIiusC8t6PiZxMLIb9FyHX1I3mEgM4Bt2Q=="
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -6317,9 +6330,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
-      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -6529,6 +6542,25 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-redux": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -6576,6 +6608,20 @@
       "requires": {
         "picomatch": "^2.0.7"
       }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
@@ -7725,6 +7771,11 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -8378,7 +8429,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8396,11 +8448,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8413,15 +8467,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8524,7 +8581,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8534,6 +8592,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8546,17 +8605,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8573,6 +8635,7 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -8628,7 +8691,8 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -8653,7 +8717,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8663,6 +8728,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8731,7 +8797,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8761,6 +8828,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8778,6 +8846,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8816,11 +8885,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -36,10 +36,14 @@
     "express": "^4.17.1",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.3.5",
-    "prettier": "^2.0.4",
+    "next-redux-wrapper": "^6.0.0",
+    "prettier": "2.0.2",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-redux": "^7.2.0",
+    "redux": "^4.0.5",
+    "redux-thunk": "^2.3.0",
     "socket.io": "^2.3.0",
     "socket.io-client": "^2.3.0"
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,21 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import App from 'next/app';
+import wrapper from '../state/store';
+
+class MyApp extends App {
+  static getInitialProps = async ({ Component, ctx }) => {
+    return {
+      pageProps: {
+        ...(Component.getInitialProps ? await Component.getInitialProps(ctx) : {}),
+      },
+    };
+  };
+
+  render() {
+    const { Component, pageProps } = this.props;
+    return <Component {...pageProps} />;
+  }
+}
+
+export default wrapper.withRedux(MyApp);

--- a/pages/now-showing.js
+++ b/pages/now-showing.js
@@ -15,11 +15,9 @@ export default function NowShowing() {
   const dispatch = useDispatch();
   const messages = useSelector((state) => state.chat.messages);
 
-  useEffect(() => {
-    socket.on('message', (data) => {
-      dispatch(actions.receivedMessage(data));
-    });
-  }, []);
+  socket.on('message', (data) => {
+    dispatch(actions.receivedMessage(data));
+  });
 
   const sendMessage = () => {
     const testMessage = Date.now().toString();

--- a/pages/now-showing.js
+++ b/pages/now-showing.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
 import io from 'socket.io-client';
+import { useDispatch, useSelector } from 'react-redux';
 import Layout from '../components/Layout';
+import * as actions from '../state/actions';
 
 const twitchUserName = 'linkywolfe';
 const socketURL =
@@ -10,12 +12,20 @@ const socketURL =
 const socket = io(socketURL);
 
 export default function NowShowing() {
+  const dispatch = useDispatch();
+  const messages = useSelector((state) => state.chat.messages);
+
   useEffect(() => {
     socket.on('message', (data) => {
       console.log(data);
       // socket.emit('my other event', { my: 'data' });
     });
   }, []);
+
+  const sendMessage = () => {
+    const testMessage = Date.now().toString();
+    dispatch(actions.sendMessage(testMessage));
+  };
 
   return (
     <Layout theme="dark">
@@ -28,6 +38,17 @@ export default function NowShowing() {
         allowFullScreen="true"
         title="twitch stream"
       />
+      <button type="button" aria-label="Test Button" onClick={sendMessage}>
+        Send Test Message
+      </button>
+      <div>
+        <h1>All Messages</h1>
+        <ul>
+          {messages.map((message) => (
+            <li key={message}>{message}</li>
+          ))}
+        </ul>
+      </div>
     </Layout>
   );
 }

--- a/pages/now-showing.js
+++ b/pages/now-showing.js
@@ -17,8 +17,7 @@ export default function NowShowing() {
 
   useEffect(() => {
     socket.on('message', (data) => {
-      console.log(data);
-      // socket.emit('my other event', { my: 'data' });
+      dispatch(actions.receivedMessage(data));
     });
   }, []);
 

--- a/pages/now-showing.js
+++ b/pages/now-showing.js
@@ -23,7 +23,7 @@ export default function NowShowing() {
 
   const sendMessage = () => {
     const testMessage = Date.now().toString();
-    dispatch(actions.sendMessage(testMessage));
+    dispatch(actions.sendMessage(socket, testMessage));
   };
 
   return (

--- a/state/actionTypes.js
+++ b/state/actionTypes.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export const SEND_MESSAGE = 'chat/SEND_MESSAGE';
+export const RECEIVED_MESSAGE = 'chat/RECEIVED_MESSAGE';

--- a/state/actionTypes.js
+++ b/state/actionTypes.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const SEND_MESSAGE = 'chat/SEND_MESSAGE';

--- a/state/actions.js
+++ b/state/actions.js
@@ -6,3 +6,9 @@ export const sendMessage = (message) => (dispatch) =>
     type: actionTypes.SEND_MESSAGE,
     message,
   });
+
+export const receivedMessage = (message) => (dispatch) =>
+  dispatch({
+    type: actionTypes.RECEIVED_MESSAGE,
+    message,
+  });

--- a/state/actions.js
+++ b/state/actions.js
@@ -1,0 +1,8 @@
+import * as actionTypes from './actionTypes';
+
+// eslint-disable-next-line import/prefer-default-export
+export const sendMessage = (message) => (dispatch) =>
+  dispatch({
+    type: actionTypes.SEND_MESSAGE,
+    message,
+  });

--- a/state/actions.js
+++ b/state/actions.js
@@ -1,11 +1,14 @@
 import * as actionTypes from './actionTypes';
 
 // eslint-disable-next-line import/prefer-default-export
-export const sendMessage = (message) => (dispatch) =>
-  dispatch({
+export const sendMessage = (socketInstance, message) => (dispatch) => {
+  socketInstance.emit('message', message);
+
+  return dispatch({
     type: actionTypes.SEND_MESSAGE,
     message,
   });
+};
 
 export const receivedMessage = (message) => (dispatch) =>
   dispatch({

--- a/state/index.js
+++ b/state/index.js
@@ -1,0 +1,21 @@
+import { combineReducers } from 'redux';
+import * as actionTypes from './actionTypes';
+
+const initialState = {
+  messages: [],
+};
+
+const chatReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case actionTypes.SEND_MESSAGE:
+      return { ...state, messages: [...state.messages, action.message] };
+    default:
+      return state;
+  }
+};
+
+const rootReducer = combineReducers({
+  chat: chatReducer,
+});
+
+export default rootReducer;

--- a/state/initialState.js
+++ b/state/initialState.js
@@ -1,0 +1,5 @@
+export default {
+  chat: {
+    messages: [],
+  },
+};

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -1,12 +1,12 @@
 import { combineReducers } from 'redux';
+import { HYDRATE } from 'next-redux-wrapper';
 import * as actionTypes from './actionTypes';
+import initialState from './initialState';
 
-const initialState = {
-  messages: [],
-};
-
-const chatReducer = (state = initialState, action) => {
+const chatReducer = (state = initialState.chat, action) => {
   switch (action.type) {
+    case HYDRATE:
+      return { ...state, ...action.payload.chat };
     case actionTypes.SEND_MESSAGE:
       return { ...state, messages: [...state.messages, action.message] };
     default:

--- a/state/reducers.js
+++ b/state/reducers.js
@@ -8,6 +8,7 @@ const chatReducer = (state = initialState.chat, action) => {
     case HYDRATE:
       return { ...state, ...action.payload.chat };
     case actionTypes.SEND_MESSAGE:
+    case actionTypes.RECEIVED_MESSAGE:
       return { ...state, messages: [...state.messages, action.message] };
     default:
       return state;

--- a/state/store.js
+++ b/state/store.js
@@ -1,0 +1,14 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import { createWrapper } from 'next-redux-wrapper';
+import thunk from 'redux-thunk';
+import reducer from './reducers';
+import initialState from './initialState';
+
+const composeEnhancers =
+  (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
+
+const initStore = (state = initialState) => {
+  return createStore(reducer, state, composeEnhancers(applyMiddleware(thunk)));
+};
+
+export default createWrapper(initStore, { debug: true });


### PR DESCRIPTION
One challenge from the Dial Up Chat was the messy business we got into by trying to pass state values and functions to update state around our component hierarchy. To simplify this, we can use a tool like Redux that will help define a cleaner pattern for managing state across all of our components. 

This PR adds a basic Redux setup for chat that works with the Next.js. It also includes a simple example on the now-showing page that adds a new value to a list in Redux when the button is clicked. Other users who are connected to the socket will also receive your update.

If we decide to merge this, I'd highly recommend Redux DevTools browser extension (https://github.com/reduxjs/redux-devtools)! It makes it much easier to see what's happening in the redux actions and state. 