### PR TITLE
Add ESLint GitHub Action for automated PR review comments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  eslint:
+    name: runner / eslint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: eslint
+        uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review # Change reporter.


### PR DESCRIPTION
The goal of this PR is to include a new GitHub Action that will run ESLint on PRs to this repo and comment with lint errors. This will help us avoid adding new lint errors into the codebase as we start forwarding on the path of getting these fixed.

This approach uses the [reviewdog ESLint action](https://github.com/reviewdog/action-eslint).

Here's an example of what the comments look like:
<img width="718" alt="action" src="https://user-images.githubusercontent.com/6589909/80335220-a44c8d00-8821-11ea-9c8a-54845e9fe303.png">