### PR TITLE
Add styled-components to the project

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    "next/babel"
+  ],
+  "plugins": [
+    [
+      "styled-components",
+      {
+        "ssr": true,
+        "displayName": true,
+        "preprocess": false
+      }
+    ]
+  ]
+}

--- a/components/Chat.jsx
+++ b/components/Chat.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import io from 'socket.io-client';
+import { useDispatch } from 'react-redux';
+import TitleBar from './TitleBar';
+import MessageForm from './MessageForm';
+import MessageList from './MessageList';
+import * as actions from '../state/actions';
+
+const socketURL =
+  process.env.NODE_ENV === 'production'
+    ? 'https://clapcitycinema.herokuapp.com'
+    : 'http://localhost:3000';
+const socket = io(socketURL);
+
+function Chat() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    return () => {
+      socket.off('message');
+    };
+  }, []);
+
+  socket.on('message', (data) => {
+    dispatch(actions.receivedMessage(data));
+  });
+
+  return (
+    <Chat.Container>
+      <TitleBar />
+      <MessageList />
+      <MessageForm socket={socket} />
+    </Chat.Container>
+  );
+}
+
+Chat.Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 5px;
+  background-color: white;
+  box-shadow: 2px 7px 10px rgba(0, 0, 0, 0.5);
+  height: 100%;
+`;
+
+export default Chat;

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,29 +1,34 @@
 import React from 'react';
 import Link from 'next/link';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
-export default function Header(props) {
+function Header({ isMobile }) {
   return (
-    <div className="header">
+    <Header.Container>
       <Link href="/">
-        <img className="logo" src="/CCCLogo.png" alt="Clap City Cinema Logo" />
+        <Header.Logo src="/CCCLogo.png" isMobile={isMobile} alt="Clap City Cinema Logo" />
       </Link>
-      <style jsx>
-        {`
-          .header {
-            display: flex;
-            padding-left: 25px;
-            padding-top: 25px;
-            height: 80px;
-            align-items: center;
-          }
-
-          .logo {
-            position: relative;
-            height: ${props.isMobile ? 'auto' : '100%'};
-            cursor: pointer;
-          }
-        `}
-      </style>
-    </div>
+    </Header.Container>
   );
 }
+
+Header.propTypes = {
+  isMobile: PropTypes.bool.isRequired,
+};
+
+Header.Container = styled.div`
+  display: flex;
+  padding-left: 25px;
+  padding-top: 25px;
+  height: 80px;
+  align-items: center;
+`;
+
+Header.Logo = styled.img`
+  position: relative;
+  height: ${(p) => (p.isMobile ? 'auto' : '100%')};
+  cursor: pointer;
+`;
+
+export default Header;

--- a/components/Message.jsx
+++ b/components/Message.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+function Message({ user, timestamp, text }) {
+  return (
+    <div>
+      <Message.Time>{timestamp}</Message.Time>
+      <Message.Bubble>
+        <Message.User>
+          <span>{user}</span>
+        </Message.User>
+        <br />
+        <Message.Text>{text}</Message.Text>
+      </Message.Bubble>
+    </div>
+  );
+}
+
+Message.propTypes = {
+  text: PropTypes.string.isRequired,
+  user: PropTypes.string,
+  timestamp: PropTypes.string,
+};
+
+Message.defaultProps = {
+  user: 'user',
+  timestamp: '4:00PM',
+};
+
+Message.Bubble = styled.div`
+  display: inline-block;
+  border-radius: 5px;
+  background-color: #50e3c2;
+  color: white;
+  min-height: 60px;
+  max-width: 400px;
+  margin: 20px 0px 0px 10px;
+  padding: 5px 10px 5px 10px;
+`;
+
+Message.Time = styled.div`
+  color: #9b9b9b;
+  margin: 0px 10px;
+  vertical-align: middle;
+  display: inline-block;
+`;
+
+Message.Text = styled.div`
+  display: inline-block;
+  clear: both;
+  word-wrap: break-word;
+  width: 100%;
+`;
+
+Message.User = styled(Message.Text)`
+  font-weight: bold;
+`;
+
+export default Message;

--- a/components/MessageForm.jsx
+++ b/components/MessageForm.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import * as actions from '../state/actions';
+
+function MessageForm({ socket }) {
+  const dispatch = useDispatch();
+  const [inputText, setInputText] = useState('');
+
+  const resetInputText = () => setInputText('');
+
+  const onMessageChange = (e) => {
+    setInputText(e.target.value);
+  };
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    dispatch(actions.sendMessage(socket, inputText));
+    resetInputText();
+  };
+
+  return (
+    <MessageForm.Container>
+      <MessageForm.Form onSubmit={onSubmit}>
+        <MessageForm.Input onChange={onMessageChange} value={inputText} autoComplete="off" />
+      </MessageForm.Form>
+    </MessageForm.Container>
+  );
+}
+
+MessageForm.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  socket: PropTypes.any.isRequired,
+};
+
+MessageForm.Container = styled.div`
+  padding: 10px;
+`;
+
+MessageForm.Form = styled.form`
+  width: 100%;
+  display: flex;
+`;
+
+MessageForm.Input = styled.input`
+  border-radius: 5px;
+  border: 1px #979797;
+  border-style: solid;
+  border-width: 1px;
+  margin: 0;
+  appearance: none;
+  box-shadow: none;
+  border-radius: none;
+  padding-left: 5px;
+  width: 100%;
+
+  &:focus,
+  textarea:focus {
+    outline: none;
+  }
+`;
+
+export default MessageForm;

--- a/components/MessageList.jsx
+++ b/components/MessageList.jsx
@@ -1,0 +1,51 @@
+import React, { useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import Message from './Message';
+
+function MessageList() {
+  const ref = useRef(null);
+  const messages = useSelector((state) => state.chat.messages);
+
+  useEffect(() => {
+    const { scrollTop, scrollHeight } = ref.current;
+    if (scrollTop !== scrollHeight) {
+      ref.current.scrollTop = ref.current.scrollHeight;
+    }
+  }, [messages]);
+
+  return (
+    <MessageList.Container ref={ref}>
+      <MessageList.Messages>
+        {messages.map((message) => (
+          <Message text={message} key={message} />
+        ))}
+      </MessageList.Messages>
+    </MessageList.Container>
+  );
+}
+
+MessageList.Container = styled.div`
+  display: flex;
+  overflow-y: hidden;
+  height: 100%;
+  width: 100%;
+  flex: 1;
+  align-items: flex-end;
+  scrollbar-width: none;
+  padding: 0px 30px;
+  -ms-overflow-style: none;
+  position: relative;
+
+  &::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+`;
+
+MessageList.Messages = styled.div`
+  width: 100%;
+  margin: 10px 0px;
+`;
+
+export default MessageList;

--- a/components/TitleBar.jsx
+++ b/components/TitleBar.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+function TitleBar({ onlineUserCount }) {
+  return (
+    <TitleBar.Container>
+      <TitleBar.Title>Dial Up Instant Messenger</TitleBar.Title>
+      <TitleBar.Online>
+        <TitleBar.OnlineCircle />
+        {onlineUserCount === 1 ? 'ONLY YOU' : `${onlineUserCount} PEOPLE ON`}
+      </TitleBar.Online>
+    </TitleBar.Container>
+  );
+}
+
+TitleBar.propTypes = {
+  onlineUserCount: PropTypes.number,
+};
+
+TitleBar.defaultProps = {
+  onlineUserCount: 0,
+};
+
+TitleBar.Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  background-color: #ffadc6;
+  border-radius: 5px 5px 0px 0px;
+  height: 30px;
+  color: white;
+  padding: 0 10px;
+`;
+
+TitleBar.Title = styled.div`
+  font-family: 'ArialRoundedMTBold';
+  font-size: 16px;
+  text-transform: uppercase;
+`;
+
+TitleBar.Online = styled.div`
+  display: flex;
+  align-items: center;
+  font-family: arial;
+  font-size: 10px;
+`;
+
+TitleBar.OnlineCircle = styled.div`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 10px;
+  background: #7ed321;
+`;
+
+export default TitleBar;

--- a/components/TwitchStream.jsx
+++ b/components/TwitchStream.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const twitchUserName = 'linkywolfe';
+
+function TwitchStream() {
+  return (
+    <iframe
+      src={`https://player.twitch.tv/?channel=${twitchUserName}`}
+      height="100%"
+      width="100%"
+      frameBorder="0"
+      scrolling="no"
+      allowFullScreen="true"
+      title="Twitch stream"
+    />
+  );
+}
+
+export default TwitchStream;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1277,6 +1277,29 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -1773,6 +1796,17 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz",
+      "integrity": "sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11"
+      }
+    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
@@ -2141,6 +2175,11 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -2624,6 +2663,11 @@
         }
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -2703,6 +2747,16 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -7097,6 +7151,11 @@
         "kind-of": "^6.0.2"
       }
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7663,6 +7722,33 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
+          }
+        }
+      }
+    },
+    "styled-components": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.0.tgz",
+      "integrity": "sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "socket.io": "^2.3.0",
     "socket.io-client": "^2.3.0",
     "styled-components": "^5.1.0"
+  },
+  "devDependencies": {
+    "babel-plugin-styled-components": "^1.10.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "socket.io": "^2.3.0",
-    "socket.io-client": "^2.3.0"
+    "socket.io-client": "^2.3.0",
+    "styled-components": "^5.1.0"
   }
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Document from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+}

--- a/pages/now-showing.js
+++ b/pages/now-showing.js
@@ -1,69 +1,59 @@
 import React, { useEffect } from 'react';
-import io from 'socket.io-client';
-import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import Layout from '../components/Layout';
-import * as actions from '../state/actions';
+import Chat from '../components/Chat';
+import TwitchStream from '../components/TwitchStream';
 
-const twitchUserName = 'linkywolfe';
-const socketURL =
-  process.env.NODE_ENV === 'production'
-    ? 'https://clapcitycinema.herokuapp.com'
-    : 'http://localhost:3000';
-const socket = io(socketURL);
-
-export default function NowShowing(props) {
-  const { isLive } = props;
-
+export default function NowShowing({ isLive }) {
   useEffect(() => {
     if (!isLive) {
       window.location.href = '/';
     }
-  })
-
-  const dispatch = useDispatch();
-  const messages = useSelector((state) => state.chat.messages);
-
-  socket.on('message', (data) => {
-    dispatch(actions.receivedMessage(data));
   });
 
-  const sendMessage = () => {
-    const testMessage = Date.now().toString();
-    dispatch(actions.sendMessage(socket, testMessage));
-  };
-
-  return isLive ? (
+  return (
     <Layout theme="dark" nowShowing>
-      <div className='nowShowing-body'>
-        <iframe
-          src={`https://player.twitch.tv/?channel=${twitchUserName}&parent=${socketURL}`}
-          height="80%"
-          width="100%"
-          frameBorder="0"
-          scrolling="no"
-          allowFullScreen="true"
-          title="Twitch stream"
-        />
-      </div>
-      <style jsx>{`
-        .nowShowing-body {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          margin-top: 15px;
-          height: calc(100vh - 120px);
-        }
-
-        iframe {
-          width: 90%;
-        }
-      `}</style>
+      <NowShowing.Container>
+        <NowShowing.Stream>
+          <TwitchStream />
+        </NowShowing.Stream>
+        <NowShowing.Chat>
+          <Chat />
+        </NowShowing.Chat>
+      </NowShowing.Container>
     </Layout>
-  ) : null;
+  );
 }
 
+NowShowing.propTypes = {
+  isLive: PropTypes.bool,
+};
+
+NowShowing.defaultProps = {
+  isLive: true,
+};
+
+NowShowing.Container = styled.div`
+  display: flex;
+  padding: 64px;
+  height: 600px;
+`;
+
+NowShowing.Stream = styled.div`
+  flex-grow: 3;
+  margin-right: 10px;
+`;
+
+NowShowing.Chat = styled.div`
+  flex-grow: 1;
+`;
+
 NowShowing.getInitialProps = async () => {
+  if (process.env.NODE_ENV !== 'production') {
+    return { isLive: true };
+  }
+
   const baseUrl =
     process.env.NODE_ENV === 'production'
       ? 'https://clapcitycinema.herokuapp.com'


### PR DESCRIPTION
Adding this PR to propose the idea of switching over the styled-components to dealing with our styling.

After working on the Faith project and spending more time studying the differences between styled-components and styled-jsx (what we've been using so far and what comes with Next.js), I think I now have a pretty strong opinion that styled-components is a lot better.

There's always going to be a big discussion around CSS-In-JS frameworks (styled-compoents vs emotion vs styled-jsx, etc), but there's two big things that I want to call out that are relevant to this project:
- Styled Components natively supports for theming: Even though you can import a theme.js file into your component and reference its values with styled-jsx, styled-components has a <ThemeProvider> component that passes the theme with the context API AND has the ability to use functions in the theme which might be useful for our efforts in having multiple modes for the site that change whether the site is live or not.
- Styled JSX doesn't support nesting: It's nice to be able to style subcomponents quickly without having to make a new class or styled-component, but this generally isn't _too_ bad. Where it gets really annoying is when there are cases where the CSS you're writing in styled-jsx has to be a lot longer because you can't actually group related styling into the same block with nesting. This file is a great example of the implications: https://github.com/DIALUPDIGITAL/faith-chatbot/blob/master/components/MessageForm.jsx



Some helpful reading:
- https://styled-components.com/docs/advanced#theming
- https://www.smashingmagazine.com/2020/04/dark-mode-react-apps-styled-components/
