### PR TITLE
Add Google Analytics

### DIFF
--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Header from './Header';
+import { initGA, logPageView } from '../utils/analytics';
 
 const themeTypes = {
   LIGHT: 'light',
@@ -8,6 +9,15 @@ const themeTypes = {
 };
 
 class Layout extends PureComponent {
+  componentDidMount() {
+    if (!window.GA_INITIALIZED) {
+      initGA();
+      window.GA_INITIALIZED = true;
+    }
+
+    logPageView();
+  }
+
   render() {
     const { children, theme, nowShowing, isMobile } = this.props;
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -18040,6 +18040,11 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-ga": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ=="
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-ga": "^3.3.0",
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -1,12 +1,10 @@
 import ReactGA from 'react-ga';
 
 export const initGA = () => {
-  console.log('GA init');
   ReactGA.initialize('G-DVER093FPR');
 };
 
 export const logPageView = () => {
-  console.log(`Logging pageview for ${window.location.pathname}`)
   ReactGA.set({ page: window.location.pathname });
   ReactGA.pageview(window.location.pathname);
 };

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -1,0 +1,24 @@
+import ReactGA from 'react-ga';
+
+export const initGA = () => {
+  console.log('GA init');
+  ReactGA.initialize('G-DVER093FPR');
+};
+
+export const logPageView = () => {
+  console.log(`Logging pageview for ${window.location.pathname}`)
+  ReactGA.set({ page: window.location.pathname });
+  ReactGA.pageview(window.location.pathname);
+};
+
+export const logEvent = (category = '', action = '') => {
+  if (category && action) {
+    ReactGA.event({ category, action });
+  }
+};
+
+export const logException = (description = '', fatal = false) => {
+  if (description) {
+    ReactGA.exception({ description, fatal });
+  }
+};


### PR DESCRIPTION
This PR adds Google Analytics to help us understand site usage. Followed this approach: https://medium.com/@austintoddj/using-google-analytics-with-next-js-423ea2d16a98

Screenshots with GA Debugger on and temporary logs:
<img width="476" alt="Screen Shot 2021-05-27 at 2 36 43 PM" src="https://user-images.githubusercontent.com/6589909/119879407-3594a400-bef9-11eb-820f-1098e18984fc.png">
<img width="467" alt="Screen Shot 2021-05-27 at 2 36 52 PM" src="https://user-images.githubusercontent.com/6589909/119879408-3594a400-bef9-11eb-8dbf-d8e15da1999c.png">
